### PR TITLE
Prevent overflow in sorted Top-K index offsets

### DIFF
--- a/csrc/cuda_kernels/common_parts.cuh
+++ b/csrc/cuda_kernels/common_parts.cuh
@@ -212,8 +212,8 @@ struct EpilogueRunner {
             if constexpr (IS_SHORTCUT) {
                 if (warp_idx < NUM_WARPS/2) {
                     #pragma unroll 8
-                    for (uint32_t i = threadIdx.x; i < args.topk; i += NUM_THREADS/2) {
-                        smem_index_buf[i] = i < end_vocab_idx ? i : args.idx_oob_fill_value - output_idx_offset;
+                    for (uint32_t i = threadIdx.x; i < MAX_TOPK; i += NUM_THREADS/2) {
+                        smem_index_buf[i] = i;
                     }
                 } else {
                     constexpr uint32_t NUM_VALUES_PER_LDG128 = NUM_BYTES_PER_SMEM_LOAD / sizeof(ValueT);
@@ -254,7 +254,10 @@ struct EpilogueRunner {
                 OutIdxT local_indices_new[NUM_VALUES_PER_THREAD_FOR_SORT];
                 CUTE_UNROLL
                 for (uint32_t i = 0; i < NUM_VALUES_PER_THREAD_FOR_SORT; ++i)
-                    local_indices_new[i] = (OutIdxT)((int32_t)local_indices[i] + output_idx_offset);
+                    // Padding is not offset. Widen valid indices before adding, even for int64 output.
+                    local_indices_new[i] = IS_SHORTCUT && local_indices[i] >= end_vocab_idx
+                        ? (OutIdxT)args.idx_oob_fill_value
+                        : (OutIdxT)((int64_t)local_indices[i] + output_idx_offset);
                 auto store = [&]<uint32_t NUM_VALUES, typename T>(T* dst, T src[NUM_VALUES]) {
                     constexpr uint32_t NUM_BYTES_TO_STORE = NUM_VALUES * sizeof(T);
                     if constexpr (NUM_BYTES_TO_STORE <= NUM_BYTES_PER_GMEM_STORE) {

--- a/tests/test_index_offsets.py
+++ b/tests/test_index_offsets.py
@@ -1,0 +1,59 @@
+"""Run with python -m unittest discover -s tests -p test_index_offsets.py -v."""
+
+import unittest
+
+import torch
+
+
+class IndexOffsetTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is required")
+        if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+            raise unittest.SkipTest("the extension requires SM100 or SM103")
+        import deep_select
+        cls.topk = staticmethod(deep_select.topk)
+
+    def test_sorted_offsets_and_padding(self):
+        # Full backing rows meet input alignment and padding requirements.
+        vocab_size, topk = 8192, 8
+        offsets = torch.tensor([2**31 - 1, -(2**31), -1, 0, 1], dtype=torch.int32, device="cuda")
+        inputs = torch.arange(vocab_size, dtype=torch.float32, device="cuda").repeat(len(offsets), 1)
+        # Exercise selection, exact-size shortcut, partial shortcut and empty rows.
+        for end_value in (vocab_size, topk, 3, 0):
+            for fill in (2**31 - 1, -(2**31), -1):
+                with self.subTest(end=end_value, fill=fill):
+                    end = torch.full_like(offsets, end_value)
+                    values, indices = self.topk(
+                        inputs, topk, sorted=True, end=end,
+                        output_idx_offset=offsets, idx_oob_fill_value=fill,
+                        indices_type=torch.int64,
+                    )
+                    count = min(end_value, topk)
+                    selected = torch.arange(end_value - 1, end_value - count - 1, -1, device="cuda")
+                    expected_indices = torch.full_like(indices, fill)
+                    expected_indices[:, :count] = selected + offsets.to(torch.int64)[:, None]
+                    expected_values = torch.full_like(values, float("-inf"))
+                    expected_values[:, :count] = selected.to(torch.float32)
+                    torch.testing.assert_close(indices, expected_indices, rtol=0, atol=0)
+                    torch.testing.assert_close(values, expected_values, rtol=0, atol=0)
+
+    def test_int32_padding_with_representable_offsets(self):
+        inputs = torch.zeros((2, 256), device="cuda")
+        offsets = torch.tensor([-1, 1], dtype=torch.int32, device="cuda")
+        end = torch.ones_like(offsets)
+        for fill in (2**31 - 1, -(2**31)):
+            with self.subTest(fill=fill):
+                _, indices = self.topk(
+                    inputs, 8, sorted=True, end=end,
+                    output_idx_offset=offsets, idx_oob_fill_value=fill,
+                    indices_type=torch.int32,
+                )
+                expected = torch.full_like(indices, fill)
+                expected[:, 0] = offsets
+                torch.testing.assert_close(indices, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1.

Sorted Top-K indices can overflow before conversion to int64: selecting index 1 with offset `2147483647` evaluates a signed int32 addition instead of producing `2147483648`. Short rows also subtract the offset from the padding sentinel, which overflows for the default fill and offset `-1`.

Widen selected indices before adding the offset. Initialize raw indices for the short-row sort and identify padding by indices outside the row's valid range. Write `idx_oob_fill_value` directly for those entries, removing sentinel offset arithmetic.

Added CUDA tests for selection, exact-size, partial and empty rows, extreme offsets and fill values, and representable int32 outputs.

Validation: the sorted FP32, `MAX_TOPK=512` translation units compile for SM100a with both int32 and int64 indices using NVCC 13.3. Python syntax compilation and `git diff --check` pass. Host copies of the original expressions reproduce UBSan failures; a candidate arithmetic model passes 45 boundary combinations under UBSan. These host checks and compilation checks are not kernel execution results.
