### PR TITLE
Bound Top-K output stores and validate input padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ values, indices = deep_select.topk(
 # indices: (batch_size, topk) of indices_type
 ```
 
-The row stride of the input tensor (`x`) must be aligned to `deep_select.get_stride_requirement()[0]` bytes. For unaligned inputs, padding is necessary.
+The row stride of the input tensor (`x`) must be aligned to `deep_select.get_stride_requirement()[0]` bytes, and its data pointer must be 32-byte aligned. The backing allocation must include the final row rounded up to 128 bytes, because TMA loads complete 128-byte tiles. Allocate padded rows first, then slice to the logical vocabulary width; a row stride alone does not guarantee that the final row has padding.
 
-Both outputs are allocated by the call, and their strides are aligned to `deep_select.get_stride_requirement()[1]` bytes (so they may be non-contiguous). Pass `output_idx=` to write indices into a buffer you own, and that buffer must satisfy the same stride requirement.
+Both outputs are allocated by the call, and their strides are aligned to `deep_select.get_stride_requirement()[1]` bytes (so they may be non-contiguous). Pass `output_idx=` to write indices into a buffer you own. That buffer must satisfy the same stride requirement, have a 32-byte-aligned data pointer and non-overlapping rows, and be contiguous in its last dimension. Only its logical elements are written; storage padding after the final element is not required.
 
 For the full signature, see [`deep_select/interface.py`](deep_select/interface.py).
 

--- a/csrc/api.cpp
+++ b/csrc/api.cpp
@@ -88,6 +88,34 @@ void topk(
         check_dim0_stride("value", *output_value, OUTPUT_STRIDE_ALIGNMENT_REQUIREMENT);
     }
 
+    // Row strides do not guarantee alignment of a sliced tensor's first row.
+    auto check_pointer_alignment = [](const char* name, const torch::Tensor& tensor) {
+        TORCH_CHECK(reinterpret_cast<uintptr_t>(tensor.data_ptr()) % 32 == 0,
+                    name, ".data_ptr() must be 32-byte aligned");
+    };
+    check_pointer_alignment("input", input);
+    check_pointer_alignment("output_index", output_index);
+    if (output_value.has_value())
+        check_pointer_alignment("output_value", *output_value);
+    TORCH_CHECK(batch_size <= 1 || output_index.stride(0) >= topk,
+                "output_index rows must not overlap");
+    if (output_value.has_value())
+        TORCH_CHECK(batch_size <= 1 || output_value->stride(0) >= topk,
+                    "output_value rows must not overlap");
+
+    // The 3D TMA descriptor rounds the vocabulary dimension up to 128 bytes.
+    // The final row needs actual backing storage for that padding as well.
+    if (batch_size > 0 && vocab_size > 0) {
+        const uint64_t itemsize = input.element_size();
+        const uint64_t row_bytes = uint64_t(vocab_size) * itemsize;
+        const uint64_t padded_row_bytes = (row_bytes + 127) / 128 * 128;
+        const uint64_t last_row_offset =
+            (uint64_t(input.storage_offset()) + uint64_t(batch_size - 1) * input.stride(0)) * itemsize;
+        const uint64_t storage_bytes = input.storage().nbytes();
+        TORCH_CHECK(last_row_offset <= storage_bytes && padded_row_bytes <= storage_bytes - last_row_offset,
+                    "input backing storage must include the final row padded to a multiple of 128 bytes");
+    }
+
     cudaDeviceProp* device_prop = at::cuda::getDeviceProperties(at::cuda::current_device());
     TORCH_CHECK(device_prop != nullptr);
     TopkSelectArgs args = {

--- a/csrc/cuda_kernels/common_parts.cuh
+++ b/csrc/cuda_kernels/common_parts.cuh
@@ -93,6 +93,21 @@ void st_global(ValueT* ptr, ValueT src[NUM_VALUES]) {
     }
 }
 
+// Keep vector stores for complete chunks; callers own only the logical row,
+// even when its backing storage contains additional elements.
+template<uint32_t NUM_VALUES, typename ValueT>
+__device__ __forceinline__
+void st_global_bounded(ValueT* ptr, ValueT src[NUM_VALUES], uint32_t remaining) {
+    if (remaining >= NUM_VALUES) {
+        st_global<NUM_VALUES>(ptr, src);
+    } else {
+        CUTE_UNROLL
+        for (uint32_t j = 0; j < NUM_VALUES; ++j)
+            if (j < remaining)
+                ptr[j] = src[j];
+    }
+}
+
 template<
     typename Config,
     uint32_t MAX_TOPK,
@@ -165,7 +180,7 @@ struct EpilogueRunner {
                     CUTE_UNROLL
                     for (uint32_t j = 0; j < NUM_OUTPUT_IDXS_PER_STORE; ++j)
                         out[j] = i+j < end_vocab_idx ? (OutIdxT)(i+j) + output_idx_offset : args.idx_oob_fill_value;
-                    STORE_TO_GMEM(result_indices + i, out);
+                    st_global_bounded<NUM_OUTPUT_IDXS_PER_STORE>(result_indices + i, out, args.topk - i);
                 }
 
                 // Save values into `result_values`, if `RETURN_VALUE` is `True`
@@ -179,7 +194,7 @@ struct EpilogueRunner {
                         CUTE_UNROLL
                         for (uint32_t j = 0; j < NUM_VALUES_PER_LOAD_STORE; ++j)
                             values[j] = i+j < end_vocab_idx ? values[j] : oob_fill_value;
-                        STORE_TO_GMEM(result_values + i, values);
+                        st_global_bounded<NUM_VALUES_PER_LOAD_STORE>(result_values + i, values, args.topk - i);
                     }
                 }
             } else {
@@ -193,7 +208,7 @@ struct EpilogueRunner {
                     CUTE_UNROLL
                     for (uint32_t j = 0; j < NUM_OUTPUT_IDX_PER_ROUND; ++j)
                         out[j] = (OutIdxT)indices_u32[j] + output_idx_offset;
-                    st_global<NUM_OUTPUT_IDX_PER_ROUND>(result_indices + i, out);
+                    st_global_bounded<NUM_OUTPUT_IDX_PER_ROUND>(result_indices + i, out, args.topk - i);
                 }
 
                 if constexpr (Config::return_value) {
@@ -203,7 +218,7 @@ struct EpilogueRunner {
                     for (uint32_t i = threadIdx.x * NUM_VALUES_PER_ROUND; i < args.topk; i += NUM_THREADS * NUM_VALUES_PER_ROUND) {
                         UIntValueT values[NUM_VALUES_PER_ROUND];
                         ld_shared<NUM_VALUES_PER_ROUND>(values, (UIntValueT*)(smem_value_buf + i));
-                        st_global<NUM_VALUES_PER_ROUND>((UIntValueT*)(result_values + i), values);
+                        st_global_bounded<NUM_VALUES_PER_ROUND>((UIntValueT*)(result_values + i), values, args.topk - i);
                     }
                 }
             }
@@ -258,15 +273,15 @@ struct EpilogueRunner {
                 auto store = [&]<uint32_t NUM_VALUES, typename T>(T* dst, T src[NUM_VALUES]) {
                     constexpr uint32_t NUM_BYTES_TO_STORE = NUM_VALUES * sizeof(T);
                     if constexpr (NUM_BYTES_TO_STORE <= NUM_BYTES_PER_GMEM_STORE) {
-                        // Don't need to do OOB check because the output array is at least padded to the maximum width of global store.
-                        st_global<NUM_VALUES>(dst, src);
+                        st_global_bounded<NUM_VALUES>(dst, src, args.topk - thread_offset);
                     } else {
                         static_assert(NUM_BYTES_TO_STORE % NUM_BYTES_PER_GMEM_STORE == 0);
                         CUTE_UNROLL
                         for (uint32_t i = 0; i < NUM_BYTES_TO_STORE; i += NUM_BYTES_PER_GMEM_STORE) {
                             uint32_t elem_offset = i / sizeof(T);
                             if (thread_offset + elem_offset < args.topk)
-                                STORE_TO_GMEM(dst+elem_offset, src+elem_offset);
+                                st_global_bounded<NUM_BYTES_PER_GMEM_STORE / sizeof(T)>(
+                                    dst+elem_offset, src+elem_offset, args.topk - thread_offset - elem_offset);
                         }
                     }
                 };

--- a/deep_select/interface.py
+++ b/deep_select/interface.py
@@ -33,6 +33,7 @@ def topk(
     """
     Arguments:
         input: (b, vocab_size), dtype=torch.bfloat16/torch.float. stride(0) must be a multiple of `deep_select.get_stride_requirement()[0]` bytes, and stride(1) must be 1.
+               The data pointer must be 32-byte aligned. Backing storage must extend through the final row rounded up to 128 bytes; allocate padded rows before slicing to vocab_size.
         topk: int. Select topk elements for each row.
         sorted: bool. Whether to return sorted **output_val**. Only supports fp32.
         begin(optional): (b,), dtype=int32. CURRENTLY NOT SUPPORTED. The left(inclusive) range for input row, default is 0.
@@ -42,7 +43,7 @@ def topk(
         indices_type: torch.dtype. The output indices dtype, only support torch.int32 and torch.int64.
         sorted_index: bool. Whether to return sorted **output_idx**.
         hint(optional): CURRENTLY NOT SUPPORTED
-        output_idx(optional): (b, topk), dtype=indices_type. A contiguous tensor to store output.
+        output_idx(optional): (b, topk), dtype=indices_type. stride(1) must be 1, stride(0) in bytes must be a multiple of `deep_select.get_stride_requirement()[1]`, and the data pointer must be 32-byte aligned. Only the logical output elements are written; no trailing storage padding is required.
         output_idx_offset(optional): (b,), dtype=int32. If provided, all output_idx (`idx_oob_fill_value` not included) will += output_idx_offset.
         idx_oob_fill_value: int. See comments above when end[i]-begin[i]<topk.
         return_value: bool. If False, only return indices without values to accelerate the kernel. The return value is still a Tuple, but the first element will be None.

--- a/tests/test_memory_boundaries.py
+++ b/tests/test_memory_boundaries.py
@@ -1,0 +1,84 @@
+"""Run with python -m unittest tests.test_memory_boundaries on SM100/SM103.
+
+Also run under compute-sanitizer --tool memcheck for allocation-boundary checks.
+"""
+import unittest
+
+import torch
+
+
+class MemoryBoundaries(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+            raise unittest.SkipTest("requires an SM100/SM103 GPU")
+        import deep_select
+        cls.topk = staticmethod(deep_select.topk)
+
+    def test_output_canaries(self):
+        for dtype in (torch.float32, torch.bfloat16):
+            for index_dtype in (torch.int32, torch.int64):
+                for mode in ("unsorted", "index", "value"):
+                    if dtype == torch.bfloat16 and mode == "value":
+                        continue
+                    for k in (1, 3, 7, 9, 17, 1025):
+                        for shortcut in (False, True):
+                            with self.subTest(dtype=dtype, index_dtype=index_dtype, mode=mode, k=k, shortcut=shortcut):
+                                # Rounded rows also provide the TMA input padding.
+                                x = torch.arange(2048, device="cuda", dtype=torch.float32).repeat(2, 1).to(dtype)
+                                width = (k + 31) // 32 * 32 + 32
+                                backing = torch.full((2, width), -123, device="cuda", dtype=index_dtype)
+                                output = backing[:, :k]
+                                end_value = min(k, 5) if shortcut else 2048
+                                end = torch.full((2,), end_value, device="cuda", dtype=torch.int32)
+                                values, indices = self.topk(x, k, end=end, indices_type=index_dtype,
+                                                           output_idx=output, sorted=mode == "value",
+                                                           sorted_index=mode == "index")
+                                torch.cuda.synchronize()
+                                self.assertTrue(torch.all(backing[:, k:] == -123).item())
+                                count = min(k, end_value)
+                                selected = indices[:, :count].long()
+                                self.assertTrue(torch.all((selected >= 0) & (selected < end_value)).item())
+                                torch.testing.assert_close(values[:, :count], x.gather(1, selected))
+                                expected = x[:, :end_value].topk(count).values.sort(dim=1).values
+                                torch.testing.assert_close(values[:, :count].sort(dim=1).values, expected)
+
+    def test_minimal_output_storage(self):
+        x = torch.ones((2, 256), device="cuda")
+        # Exactly 36 bytes: row zero at byte 0, row one at byte 32.
+        output = torch.empty(9, device="cuda", dtype=torch.int32).as_strided((2, 1), (8, 1))
+        end = torch.ones(2, device="cuda", dtype=torch.int32)
+        _, indices = self.topk(x, 1, end=end, output_idx=output, indices_type=torch.int32)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(indices, torch.zeros_like(indices))
+
+    def test_input_requires_final_row_padding(self):
+        for dtype in (torch.float32, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                stride = 1024 // dtype.itemsize
+                width = stride + 1
+                row_stride = 2 * stride
+                x = torch.ones(row_stride + width, device="cuda", dtype=dtype).as_strided((2, width), (row_stride, 1))
+                with self.assertRaisesRegex(RuntimeError, "input backing storage"):
+                    self.topk(x, 1)
+                padded = torch.ones((2, row_stride), device="cuda", dtype=dtype)[:, :width]
+                values, _ = self.topk(padded, 1)
+                torch.testing.assert_close(values, torch.ones_like(values))
+
+    def test_misaligned_views(self):
+        x = torch.ones((2, 512), device="cuda")
+        with self.assertRaisesRegex(RuntimeError, "input.data_ptr"):
+            self.topk(x[:, 1:257], 1)
+        backing = torch.empty((2, 16), device="cuda", dtype=torch.int32)
+        with self.assertRaisesRegex(RuntimeError, "output_index.data_ptr"):
+            self.topk(x, 1, output_idx=backing[:, 1:2], indices_type=torch.int32)
+
+    def test_output_rows_must_not_overlap(self):
+        x = torch.ones((2, 256), device="cuda")
+        output = torch.empty((1, 8), device="cuda", dtype=torch.int32)[:, :1].expand(2, 1)
+        with self.assertRaisesRegex(RuntimeError, "output_index rows must not overlap"):
+            self.topk(x, 1, output_idx=output, indices_type=torch.int32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #5.

Caller-provided index views can end in the middle of a vector store. A `(2, 1)` int32 view with stride `(8, 1)` needs only 36 bytes, but the shortcut's second 32-byte store ends at byte 64. The epilogue now retains vector stores for complete chunks and writes only valid elements in the final chunk, including sorted-value and shortcut paths.

The binding also checks 32-byte pointer alignment and non-overlapping output rows. It rejects input allocations that do not cover the final row rounded to the TMA descriptor's 128-byte width. The input padding requirement is documented alongside an updated contract for caller-provided output buffers.

Added tests cover output canaries, minimally backed outputs, input padding, pointer offsets, and overlapping output rows.

This PR and #4 touch the same validation/launch boundary in `csrc/api.cpp`. When combining them, retain these memory checks before the input-device guard and property lookup from #4.

Validation: C++20 syntax check of `csrc/api.cpp`; NVCC 13.3 compilation of the FP32 sorted-value, int32, `max_topk=4096` specialization for SM100a and the BF16 unsorted, int64, `max_topk=512` specialization for SM103a; Python compilation and `git diff --check`.
