### PR TITLE
Reduce redundant Top-K host setup

### DIFF
--- a/csrc/3rdparty/kerutils/include/kerutils/host/host.h
+++ b/csrc/3rdparty/kerutils/include/kerutils/host/host.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdio>
+#include <array>
 #include <exception>
 #include <memory>
 #include <string>
@@ -97,81 +98,70 @@ inline __host__ __device__ constexpr T find_next_power_of_2(const T& x) {
     return find_next_power_of_2<T, LOWER_BOUND*2>(x);
 }
 
-// A wrapper for make_tensor_map
-static inline CUtensorMap make_tensor_map(
-    const std::vector<uint64_t> &size,
-    const std::vector<uint64_t> &strides,   // PAY ATTENTION: In BYTES
-    const std::vector<uint32_t> &box_size,
+// Driver symbols are independent of tensor storage and the current device.
+// Inline linkage shares this cache across translation units. A failed lookup
+// throws before initialization completes, so a later call retries it.
+inline PFN_cuTensorMapEncodeTiled_v12000 get_tensor_map_encoder() {
+    static const auto encoder = [] {
+        cudaDriverEntryPointQueryResult cuda_status;
+        void* pfn = nullptr;
+#if CUDA_VERSION >= 13000
+        KU_CUDA_CHECK(cudaGetDriverEntryPointByVersion(
+            "cuTensorMapEncodeTiled", &pfn, 12000, cudaEnableDefault, &cuda_status));
+#else
+        KU_CUDA_CHECK(cudaGetDriverEntryPoint(
+            "cuTensorMapEncodeTiled", &pfn, cudaEnableDefault, &cuda_status));
+#endif
+        KU_ASSERT(cuda_status == cudaDriverEntryPointSuccess && pfn != nullptr,
+                  "Failed to load `cuTensorMapEncodeTiled`. cuda_status = %d", cuda_status);
+        return reinterpret_cast<PFN_cuTensorMapEncodeTiled_v12000>(pfn);
+    }();
+    return encoder;
+}
+
+namespace detail {
+
+inline CUtensorMap encode_tensor_map(
+    int dim,
+    const uint64_t* size,
+    const uint64_t* strides,
+    const uint32_t* box_size,
     void* global_ptr,
     CUtensorMapDataType data_type,
     CUtensorMapSwizzle swizzle_mode,
     CUtensorMapL2promotion l2_promotion,
-    CUtensorMapInterleave interleave_mode = CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
-    CUtensorMapFloatOOBfill oob_fill = CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
-    const std::vector<uint32_t> &element_strides_ = {}
+    CUtensorMapInterleave interleave_mode,
+    CUtensorMapFloatOOBfill oob_fill,
+    const uint32_t* element_strides
 ) {
-    int dim = size.size();
-    KU_ASSERT(dim >= 1);
-    
-    std::vector<uint32_t> element_strides;
-    if (element_strides_.empty()) {
-        for (int i = 0; i < dim; ++i)
-            element_strides.push_back(1);
-    } else {
-        element_strides = element_strides_;
-    }
-    KU_ASSERT(strides.size() == (uint32_t)dim-1 && box_size.size() == (uint32_t)dim && element_strides.size() == (uint32_t)dim);
-
-    auto call_cuTensorMapEncodeTiled = [&]<typename... Args>(Args... args) {
-        cudaDriverEntryPointQueryResult cuda_status;
-        void* pfn = nullptr;
-#if (__CUDACC_VER_MAJOR__ > 12)
-        KU_CUDA_CHECK(cudaGetDriverEntryPointByVersion(
-            "cuTensorMapEncodeTiled",
-            &pfn, 12000,
-            cudaEnableDefault,
-            &cuda_status));
-#else
-        KU_CUDA_CHECK(cudaGetDriverEntryPoint(
-            "cuTensorMapEncodeTiled",
-            &pfn,
-            cudaEnableDefault,
-            &cuda_status));
-#endif
-        if (cuda_status != cudaDriverEntryPointSuccess) {
-            KU_ASSERT(false, "Failed to load `cuTensorMapEncodeTiled`. cuda_status = %d", cuda_status);
-        }
-        return reinterpret_cast<decltype(&cuTensorMapEncodeTiled)>(pfn)(args...); \
-    };
-
     CUtensorMap result;
-    CUresult ret_code = call_cuTensorMapEncodeTiled(
+    CUresult ret_code = get_tensor_map_encoder()(
         &result,
         data_type,
         dim,
         global_ptr,
-        size.data(),
-        strides.data(),
-        box_size.data(),
-        element_strides.data(),
+        size,
+        strides,
+        box_size,
+        element_strides,
         interleave_mode,
         swizzle_mode,
         l2_promotion,
         oob_fill
     );
     if (ret_code != CUresult::CUDA_SUCCESS) {
-        auto print_vector = [&](auto t, const char* fmt, const char end='\n') {
-            for (auto elem : t) {
-                printf(fmt, elem);
+        auto print_vector = [&](auto t, int count, const char* fmt, const char end='\n') {
+            for (int i = 0; i < count; ++i) {
+                printf(fmt, t[i]);
             }
             printf("%c", end);
         };
         fprintf(stderr, "Failed to create tensormap\n");
         fprintf(stderr, "Dim: %d\n", dim);
-        printf("size: "); print_vector(size, "%lu ");
-        printf("strides: "); print_vector(strides, "%lu ");
-        printf("box_size: "); print_vector(box_size, "%u ");
-        printf("element_strides: "); print_vector(element_strides, "%u ");
+        printf("size: "); print_vector(size, dim, "%lu ");
+        printf("strides: "); print_vector(strides, dim-1, "%lu ");
+        printf("box_size: "); print_vector(box_size, dim, "%u ");
+        printf("element_strides: "); print_vector(element_strides, dim, "%u ");
         printf("global ptr: 0x%lx\n", (int64_t)global_ptr);
         printf("data_type: %d\n", (int)data_type);
         printf("swizzle_mode: %d\n", (int)swizzle_mode);
@@ -181,6 +171,54 @@ static inline CUtensorMap make_tensor_map(
         KU_ASSERT(false);
     }
     return result;
+}
+
+} // namespace detail
+
+// Preserve the dynamically ranked interface for existing callers.
+static inline CUtensorMap make_tensor_map(
+    const std::vector<uint64_t>& size,
+    const std::vector<uint64_t>& strides, // In bytes
+    const std::vector<uint32_t>& box_size,
+    void* global_ptr,
+    CUtensorMapDataType data_type,
+    CUtensorMapSwizzle swizzle_mode,
+    CUtensorMapL2promotion l2_promotion,
+    CUtensorMapInterleave interleave_mode = CU_TENSOR_MAP_INTERLEAVE_NONE,
+    CUtensorMapFloatOOBfill oob_fill = CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    const std::vector<uint32_t>& element_strides_ = {}
+) {
+    int dim = size.size();
+    KU_ASSERT(dim >= 1);
+    std::vector<uint32_t> element_strides = element_strides_.empty()
+        ? std::vector<uint32_t>(dim, 1) : element_strides_;
+    KU_ASSERT(strides.size() == (uint32_t)dim-1 && box_size.size() == (uint32_t)dim && element_strides.size() == (uint32_t)dim);
+    return detail::encode_tensor_map(dim, size.data(), strides.data(), box_size.data(),
+        global_ptr, data_type, swizzle_mode, l2_promotion, interleave_mode, oob_fill, element_strides.data());
+}
+
+// Fixed rank keeps metadata on the stack; the descriptor is still rebuilt for
+// every call's pointer, dimensions, and strides.
+template<size_t Rank>
+inline CUtensorMap make_tensor_map(
+    const std::array<uint64_t, Rank>& size,
+    const std::array<uint64_t, Rank-1>& strides, // In bytes
+    const std::array<uint32_t, Rank>& box_size,
+    void* global_ptr,
+    CUtensorMapDataType data_type,
+    CUtensorMapSwizzle swizzle_mode,
+    CUtensorMapL2promotion l2_promotion,
+    CUtensorMapInterleave interleave_mode = CU_TENSOR_MAP_INTERLEAVE_NONE,
+    CUtensorMapFloatOOBfill oob_fill = CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    const std::array<uint32_t, Rank>& element_strides = [] {
+        std::array<uint32_t, Rank> ones;
+        ones.fill(1);
+        return ones;
+    }()
+) {
+    static_assert(Rank >= 1 && Rank <= 5);
+    return detail::encode_tensor_map(Rank, size.data(), strides.data(), box_size.data(),
+        global_ptr, data_type, swizzle_mode, l2_promotion, interleave_mode, oob_fill, element_strides.data());
 }
 
 // Given strides (in number of elements), this function converts their datatype in uint64_t and then multiplies by elem_size

--- a/csrc/cuda_kernels/common_parts.cuh
+++ b/csrc/cuda_kernels/common_parts.cuh
@@ -411,7 +411,7 @@ public:
         constexpr CUtensorMapDataType dtype = std::is_same_v<ValueT, nv_bfloat16>
             ? CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
             : CU_TENSOR_MAP_DATA_TYPE_FLOAT32;
-        return ku::make_tensor_map(
+        return ku::make_tensor_map<3>(
             // Split args.vocab_size into two dims because
             //   - TMA requires innermost box dim <= swizzle size
             //   - To avoid OOB as we have `INPUT_STRIDE_ALIGNMENT_REQUIREMENT`
@@ -420,7 +420,7 @@ public:
                 ku::ceil_div((uint64_t)args.vocab_size, (uint64_t)NUM_ELEMS_PER_TMA_ROW),
                 args.batch_size
             },
-            ku::make_stride_helper<uint64_t>({NUM_ELEMS_PER_TMA_ROW, args.stride_input_batch}, sizeof(ValueT)),
+            {uint64_t(NUM_ELEMS_PER_TMA_ROW) * sizeof(ValueT), uint64_t(args.stride_input_batch) * sizeof(ValueT)},
             {
                 NUM_ELEMS_PER_TMA_ROW,
                 NUM_TMA_ROWS_PER_SEG,

--- a/csrc/cuda_kernels/v3/topk_select.cuh
+++ b/csrc/cuda_kernels/v3/topk_select.cuh
@@ -130,7 +130,6 @@ void run_topk_select_kernel(const TopkSelectArgs &args) {
     auto kernel = topk_kernel<Kernel>;
     constexpr size_t smem_size = sizeof(typename Kernel::SharedMemoryPlan);
     KU_ASSERT(smem_size * Kernel::TARGET_OCCUPANCY <= args.shared_memory_size_per_sm);
-    KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
     KU_ASSERT(args.stride_input_batch % 8 == 0, "stride_input_batch must be 16B-aligned");
     typename Kernel::TmaParams tma_params = {Kernel::make_topk_tensor_map(args)};

--- a/csrc/cuda_kernels/v3_cluster/topk_select.cuh
+++ b/csrc/cuda_kernels/v3_cluster/topk_select.cuh
@@ -286,10 +286,6 @@ void run_topk_select_kernel(const TopkSelectArgs &args) {
     auto kernel = topk_kernel<Kernel>;
     constexpr size_t smem_size = sizeof(typename Kernel::SharedMemoryPlanBF16Cluster);
     KU_ASSERT(smem_size * Kernel::TARGET_OCCUPANCY <= args.shared_memory_size_per_sm);
-    KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-    if constexpr (Kernel::CLUSTER_SIZE > 8) {
-        KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
-    }
 
     KU_ASSERT(args.stride_input_batch % 8 == 0, "stride_input_batch must be 16B-aligned");
     typename Kernel::TmaParams tma_params = {Kernel::make_topk_tensor_map(args)};

--- a/csrc/cuda_kernels/v3_fp32/topk_select.cuh
+++ b/csrc/cuda_kernels/v3_fp32/topk_select.cuh
@@ -589,7 +589,6 @@ void run_topk_select_kernel(const TopkSelectArgs &args) {
     auto kernel = topk_kernel<Kernel>;
     constexpr size_t smem_size = sizeof(typename Kernel::SharedMemoryPlanFP32);
     KU_ASSERT(smem_size * Kernel::TARGET_OCCUPANCY <= args.shared_memory_size_per_sm);
-    KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
     KU_ASSERT(args.stride_input_batch % 4 == 0, "stride_input_batch must be 16B-aligned");
     typename Kernel::TmaParams tma_params = {Kernel::make_topk_tensor_map(args)};

--- a/tests/host/README.md
+++ b/tests/host/README.md
@@ -1,0 +1,17 @@
+# Host setup regression tests
+
+These tests use real CUDA headers and a mocked driver resolver and encoder. They require CUDA 13's compiler, but do not initialize CUDA or require a GPU. The mock records encoder arguments rather than validating device-specific tensor-map constraints.
+
+From the repository root, build into a directory outside the checkout:
+
+```sh
+nvcc -std=c++20 -O2 --cudart shared -I csrc/3rdparty/kerutils/include -Xcompiler -pthread tests/host/tensor_map.cu tests/host/tensor_map_peer.cu tests/host/allocations.cpp -o /path/to/artifacts/tensor-map-test
+/path/to/artifacts/tensor-map-test
+/path/to/artifacts/tensor-map-test retry
+```
+
+The normal process tests concurrent cold initialization, one lookup shared across two translation units, current per-call tensor arguments, retry after an encoder failure, and vector/array equivalence for ranks one through five with default and explicit element strides. The separate `retry` process additionally tests runtime lookup failure, missing symbol, and a null function pointer before successful initialization. Assertion diagnostics from these intentional failures are expected.
+
+For the baseline regression, compile the same sources with `-DTEST_BASELINE` and point the include path at baseline kerutils headers. Run without `retry`: the single-lookup assertion must fail after sixteen concurrent calls. This mode excludes the new array overload and does not attempt the baseline's unsafe null-pointer call.
+
+Run either binary with `benchmark` to measure rank-three metadata preparation through its actual headers. It warms up 1,000 calls, then reports seven rounds of 200,000 calls, allocations, and resolver calls. The baseline uses the original vector/stride-helper path; the candidate uses fixed arrays. Both use the same recording mock encoder. This isolates host preparation and does not measure driver encoding, kernel launch, or end-to-end Top-K latency. Alternate baseline/candidate runs to check timing noise. The candidate additionally asserts zero steady-state allocations and lookups.

--- a/tests/host/allocations.cpp
+++ b/tests/host/allocations.cpp
@@ -1,0 +1,13 @@
+#include <cstdlib>
+#include <new>
+
+thread_local bool count_allocations = false;
+thread_local size_t allocations = 0;
+
+void* operator new(size_t size) {
+    if (count_allocations) ++allocations;
+    if (auto* ptr = std::malloc(size ? size : 1)) return ptr;
+    throw std::bad_alloc();
+}
+void operator delete(void* ptr) noexcept { std::free(ptr); }
+void operator delete(void* ptr, size_t) noexcept { std::free(ptr); }

--- a/tests/host/tensor_map.cu
+++ b/tests/host/tensor_map.cu
@@ -1,0 +1,176 @@
+// Real CUDA types and ABI, mocked driver lookup/encoder: no GPU is required.
+#include <cuda_runtime_api.h>
+#include <cudaTypedefs.h>
+#include <array>
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+#include <thread>
+#include <vector>
+#include "kerutils/host/host.h"
+
+extern thread_local bool count_allocations;
+extern thread_local size_t allocations;
+
+void encode_from_peer();
+static std::atomic<int> lookups{0}, encodes{0};
+static int lookup_failure = 0;
+static bool encode_failure = false;
+struct Arguments {
+    unsigned rank;
+    void* pointer;
+    CUtensorMapDataType dtype;
+    CUtensorMapInterleave interleave;
+    CUtensorMapSwizzle swizzle;
+    CUtensorMapL2promotion promotion;
+    CUtensorMapFloatOOBfill fill;
+    std::array<uint64_t, 5> sizes{}, strides{};
+    std::array<uint32_t, 5> boxes{}, elements{};
+    bool operator==(const Arguments&) const = default;
+};
+static thread_local Arguments recorded;
+
+static CUresult CUDAAPI encode(CUtensorMap* result, CUtensorMapDataType dtype,
+    cuuint32_t rank, void* pointer, const cuuint64_t* sizes,
+    const cuuint64_t* strides, const cuuint32_t* boxes, const cuuint32_t* elements,
+    CUtensorMapInterleave interleave, CUtensorMapSwizzle swizzle,
+    CUtensorMapL2promotion promotion, CUtensorMapFloatOOBfill fill) {
+    ++encodes;
+    assert(rank >= 1 && rank <= 5);
+    recorded = {};
+    recorded.rank = rank; recorded.pointer = pointer; recorded.dtype = dtype;
+    recorded.interleave = interleave; recorded.swizzle = swizzle;
+    recorded.promotion = promotion; recorded.fill = fill;
+    std::copy_n(sizes, rank, recorded.sizes.begin());
+    std::copy_n(strides, rank - 1, recorded.strides.begin());
+    std::copy_n(boxes, rank, recorded.boxes.begin());
+    std::copy_n(elements, rank, recorded.elements.begin());
+    std::memset(result, 0, sizeof(*result));
+    return encode_failure ? CUDA_ERROR_INVALID_VALUE : CUDA_SUCCESS;
+}
+
+extern "C" cudaError_t CUDARTAPI cudaGetDriverEntryPointByVersion(
+    const char* name, void** pointer, unsigned version, unsigned long long flags,
+    cudaDriverEntryPointQueryResult* status) {
+    ++lookups;
+    assert(std::strcmp(name, "cuTensorMapEncodeTiled") == 0);
+    assert(version == 12000 && flags == cudaEnableDefault);
+    *status = lookup_failure == 2 ? cudaDriverEntryPointSymbolNotFound : cudaDriverEntryPointSuccess;
+    *pointer = lookup_failure == 3 ? nullptr : reinterpret_cast<void*>(&encode);
+    return lookup_failure == 1 ? cudaErrorUnknown : cudaSuccess;
+}
+
+template<class F> void throws(F f) {
+    bool caught = false;
+    try { f(); } catch (const ku::KUException&) { caught = true; }
+    assert(caught);
+}
+
+#ifndef TEST_BASELINE
+template<size_t Rank> void compare_storage() {
+    std::array<uint64_t, Rank> sizes;
+    std::array<uint64_t, Rank - 1> strides;
+    std::array<uint32_t, Rank> boxes, elements;
+    sizes.fill(32); strides.fill(128); boxes.fill(1); elements.fill(2);
+    for (bool explicit_elements : {false, true}) {
+        const auto ptr = reinterpret_cast<void*>(0x2000 + Rank * 128);
+        const auto dtype = CU_TENSOR_MAP_DATA_TYPE_FLOAT32;
+        const auto swizzle = CU_TENSOR_MAP_SWIZZLE_NONE;
+        const auto promotion = CU_TENSOR_MAP_L2_PROMOTION_L2_256B;
+        const auto interleave = CU_TENSOR_MAP_INTERLEAVE_NONE;
+        const auto fill = CU_TENSOR_MAP_FLOAT_OOB_FILL_NAN_REQUEST_ZERO_FMA;
+        std::vector<uint32_t> e;
+        if (explicit_elements) e.assign(elements.begin(), elements.end());
+        ku::make_tensor_map({sizes.begin(), sizes.end()}, {strides.begin(), strides.end()},
+            {boxes.begin(), boxes.end()}, ptr, dtype, swizzle, promotion, interleave, fill, e);
+        auto expected = recorded;
+        if (explicit_elements)
+            ku::make_tensor_map<Rank>(sizes, strides, boxes, ptr, dtype, swizzle, promotion, interleave, fill, elements);
+        else
+            ku::make_tensor_map<Rank>(sizes, strides, boxes, ptr, dtype, swizzle, promotion, interleave, fill);
+        assert(recorded == expected);
+    }
+}
+#endif
+
+// Measures actual metadata wrappers with a mock encoder, not CUDA execution.
+void benchmark() {
+    constexpr int count = 200000;
+    auto prepare = [](int i) {
+        const uint64_t vocab = 8192 + (i & 31);
+#ifdef TEST_BASELINE
+        ku::make_tensor_map({32, (vocab + 31) / 32, 6},
+            ku::make_stride_helper<uint64_t>({32, 8448}, 4), {32, 8, 1},
+#else
+        ku::make_tensor_map<3>({32, (vocab + 31) / 32, 6},
+            {128, 33792}, {32, 8, 1},
+#endif
+            reinterpret_cast<void*>(0x1000), CU_TENSOR_MAP_DATA_TYPE_FLOAT32,
+            CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_L2_256B);
+        assert(recorded.sizes[1] == (vocab + 31) / 32);
+    };
+    for (int i = 0; i < 1000; ++i) prepare(i);
+    for (int round = 0; round < 7; ++round) {
+        allocations = 0;
+        const int before = lookups;
+        count_allocations = true;
+        const auto start = std::chrono::steady_clock::now();
+        for (int i = 0; i < count; ++i) prepare(i);
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        count_allocations = false;
+        std::printf("round=%d calls=%d allocations=%zu lookups=%d ns_per_call=%.3f\n",
+            round, count, allocations, int(lookups) - before,
+            std::chrono::duration<double, std::nano>(elapsed).count() / count);
+#ifndef TEST_BASELINE
+        assert(allocations == 0 && int(lookups) == before);
+#endif
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc > 1 && std::strcmp(argv[1], "benchmark") == 0) {
+        benchmark();
+        return 0;
+    }
+    if (argc > 1 && std::strcmp(argv[1], "retry") == 0) {
+        for (int failure : {1, 2, 3}) {
+            lookup_failure = failure;
+            throws(encode_from_peer);
+            assert(lookups == failure && encodes == 0);
+        }
+        lookup_failure = 0;
+    }
+    const int failed_lookups = lookups;
+    std::atomic<int> ready{0}; std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 16; ++i) threads.emplace_back([&] {
+        ++ready; while (!start.load()) std::this_thread::yield(); encode_from_peer();
+    });
+    while (ready != 16) std::this_thread::yield();
+    start = true;
+    for (auto& t : threads) t.join();
+    assert(encodes == 16);
+    assert(lookups == failed_lookups + 1);
+    ku::make_tensor_map({64, 8, 3}, {256, 2048}, {64, 2, 1},
+        reinterpret_cast<void*>(0x3000), CU_TENSOR_MAP_DATA_TYPE_BFLOAT16,
+        CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_NONE);
+    assert(recorded.pointer == reinterpret_cast<void*>(0x3000));
+    assert(recorded.sizes[0] == 64 && recorded.sizes[1] == 8 && recorded.sizes[2] == 3);
+    assert(recorded.strides[0] == 256 && recorded.strides[1] == 2048);
+    assert(recorded.boxes[1] == 2 && recorded.dtype == CU_TENSOR_MAP_DATA_TYPE_BFLOAT16);
+    assert(lookups == failed_lookups + 1); // Shared with the other translation unit.
+    encode_failure = true;
+    throws(encode_from_peer);
+    encode_failure = false;
+    encode_from_peer();
+    assert(encodes == 19 && lookups == failed_lookups + 1);
+#ifndef TEST_BASELINE
+    compare_storage<1>(); compare_storage<2>(); compare_storage<3>();
+    compare_storage<4>(); compare_storage<5>();
+#endif
+    std::puts("tensor-map host tests passed");
+}

--- a/tests/host/tensor_map_peer.cu
+++ b/tests/host/tensor_map_peer.cu
@@ -1,0 +1,9 @@
+#include <cuda_runtime_api.h>
+#include <cudaTypedefs.h>
+#include "kerutils/host/host.h"
+
+void encode_from_peer() {
+    ku::make_tensor_map({32, 4, 2}, {128, 512}, {32, 1, 1},
+                       reinterpret_cast<void*>(0x1000), CU_TENSOR_MAP_DATA_TYPE_FLOAT32,
+                       CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_NONE);
+}


### PR DESCRIPTION
Fixes #7.

Reduce repeated CPU setup before Top-K launches without changing device-side computation or caching tensor descriptors.

Cache the tensor-map encoder pointer using thread-safe local-static initialization, retrying lookup if initialization throws. Add a fixed-rank metadata path while preserving the vector helper interface. Route Top-K's rank-three metadata through stack arrays, and remove duplicate attribute setters from the three launchers; the common launcher still sets and checks the attributes for each invocation.

The host regression harness uses actual CUDA types and product headers with a recording mock resolver/encoder. It checks concurrent cold initialization, sharing across two translation units, lookup failure retries, encoder failure recovery, fresh per-call arguments, and vector/array equivalence for ranks 1–5. The same test against baseline headers fails the intended single-lookup assertion.

With 200,000 calls per round, the baseline metadata path makes 1,600,000 allocations and 200,000 lookups; the candidate makes zero of either after warmup. Across 14 rounds per variant in baseline/candidate/candidate/baseline order, median instrumented host preparation time was 457 ns versus 114 ns on an Intel i7-10875H using NVCC 13.3, `-O2`, and libstdc++. Allocation accounting and a mock encoder are included in these timings: they are not driver-encoding or end-to-end Top-K results. Reproduction commands are in `tests/host/README.md`.

Validation also includes SM100a compilation of one specialization from each of the BF16, FP32, and BF16-cluster kernel families, plus whitespace checks.
