### PR TITLE
Fall back to torch when lspci is unavailable

### DIFF
--- a/tests/kernelkit/platform.py
+++ b/tests/kernelkit/platform.py
@@ -1,5 +1,6 @@
 import enum
 import functools
+import shutil
 import subprocess
 
 
@@ -13,10 +14,17 @@ def get_current_platform() -> Platform:
     """
     Get the current platform via `lspci`
     """
-    output = subprocess.check_output(["lspci"], text=True)
-    if "3D controller: NVIDIA Corporation Device" in output:
-        return Platform.CUDA
-    return Platform.CPU_ONLY
+    if shutil.which("lspci") is not None:
+        output = subprocess.check_output(["lspci"], text=True)
+        if "3D controller: NVIDIA Corporation Device" in output:
+            return Platform.CUDA
+        return Platform.CPU_ONLY
+
+    # `lspci` is not installed, which is common inside containers. Fall back to
+    # torch, which is already a hard dependency and can see the device directly.
+    import torch
+
+    return Platform.CUDA if torch.cuda.is_available() else Platform.CPU_ONLY
 
 
 def assert_current_platform(target_platform: Platform | list[Platform]):


### PR DESCRIPTION
`tests/kernelkit/platform.py:16` runs `lspci` without checking that it exists, and `tests/kernelkit/build.py:9` calls `get_current_platform()` at module scope. `setup.py:8` imports that package, so on any machine without `lspci` — every container image that does not ship `pciutils`, for instance — the documented `pip install -v .` fails before `setup.py` does anything:

```
Traceback (most recent call last):
  File "setup.py", line 8, in <module>
    import tests.kernelkit as kk
  File "tests/kernelkit/__init__.py", line 2, in <module>
    from . import build
  File "tests/kernelkit/build.py", line 9, in <module>
    if get_current_platform() == Platform.CUDA:
  File "tests/kernelkit/platform.py", line 16, in get_current_platform
    output = subprocess.check_output(["lspci"], text=True)
FileNotFoundError: [Errno 2] No such file or directory: 'lspci'
```

`DEEP_SELECT_BUILD_TARGET_PLATFORM` cannot work around this: it is read at `setup.py:186`, but the failure happens while `setup.py:8` is still importing, so setting it changes nothing.

Keep `lspci` as the probe when it is present, and fall back to `torch.cuda.is_available()` when it is not. `torch` is already a hard dependency and `kernelkit` imports it either way.

One behavioural note: `lspci` reports an NVIDIA PCI device even when no usable driver is loaded, while `torch.cuda.is_available()` does not. On a machine that has the device but no working CUDA runtime, the fallback reports `CPU_ONLY` where `lspci` would have reported `CUDA`. That only affects machines that also lack `lspci` — wherever `lspci` exists the existing path is unchanged.

Validation: on Ubuntu 24.04 without `pciutils`, `python setup.py --version` goes from the `FileNotFoundError` above to printing `Build target: Platform.CUDA` and then hitting the unrelated `setup.py:103` assertion that `CUDA_HOME` is set. Reverting the patch restores the `FileNotFoundError`. Calling `get_current_platform()` directly returns `Platform.CUDA`. I did not run a full CUDA build, and I did not test on a machine that has `lspci`.
